### PR TITLE
re-implement sync file, add WriteSyncFileRequest, ReadSyncFileRequest…

### DIFF
--- a/src/librbd/cache/SharedPersistentObjectCacherFile.cc
+++ b/src/librbd/cache/SharedPersistentObjectCacherFile.cc
@@ -69,6 +69,50 @@ void SyncFile::open() {
   }
 }
 
+int SyncFile::open(int flag, std::string temp_name) {
+  if(temp_name.empty()) {
+    m_fd = :: open(m_name.c_str(), flag, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+  } else {
+    m_fd = :: open(temp_name.c_str(), flag, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+  }
+
+  if(m_fd == -1) {
+    return -errno;
+  }
+  return m_fd;
+}
+
+int SyncFile::rename(std::string old_name, std::string new_name) {
+  int ret;
+  ret = ::rename(old_name.c_str(), new_name.c_str());
+  
+  if(ret != 0) {
+    ldout(cct, 20) <<" rename system call file, error : "<< strerror(errno)<<dendl;
+  } 
+  
+  return ret;
+}
+
+/*
+ * remove() deletes a name from the filesystem.  It calls unlink for files, and rmdir for directories.
+ *
+ * If the removed name was the last link to a file and no processes have the file open, 
+ *  the file is deleted and the space it was using is made available for reuse.
+ * 
+ * If the name was the last link to a file, but any processes still have the file open, 
+ *  the file will remain in existence until the last file descriptor referring to it is closed.
+ *
+ */
+int SyncFile::remove(std::string delete_file_name) { 
+  int ret;
+  ret = remove(delete_file_name.c_str()); 
+  if(ret < 0) {
+    ldout(cct, 20) <<" remove, error : "<< strerror(errno)<<dendl;
+  } 
+
+  return ret;
+}
+
 void SyncFile::read(uint64_t offset, uint64_t length, ceph::bufferlist *bl, Context *on_finish) {
   on_finish->complete(read_object_from_file(bl, offset, length));
 }
@@ -109,6 +153,135 @@ int SyncFile::read_object_from_file(ceph::bufferlist* read_buf, uint64_t object_
 
   return ret;
 }
+
+// =========== SyncFile's child class ==============
+
+
+ReadSyncFileRequest::ReadSyncFileRequest(CephContext* cct, 
+                                         ContextWQ* op_work_queue, 
+                                         const std::string& file_name, 
+                                         ceph::bufferlist* read_bl, 
+                                         const uint64_t object_off, 
+                                         const uint64_t object_len, 
+                                         Context* on_finish)
+  : m_sync_file(cct, file_name),
+    m_op_work_queue(op_work_queue),
+    m_read_bl(read_bl),
+    m_object_offset(object_off),
+    m_on_finish(on_finish),
+    m_object_len(object_len)
+{}
+
+void ReadSyncFileRequest::finish(int r) {
+
+  // no such r<0 case 
+  if(r < 0) {
+    m_on_finish->complete(-1);
+    return;
+  }
+
+  int ret;
+  int flag = O_RDONLY | O_DIRECT | O_SYNC | O_NOATIME;
+
+  ret = m_sync_file.open(flag, "");
+  // no such file
+  if(ret == -ENOENT) {
+    m_on_finish->complete(-1); 
+    return;
+  }
+ 
+  // TODO error handing
+  if(ret < 0) {
+    m_on_finish->complete(-1);
+    return;
+  }
+  
+  ret = m_sync_file.read_object_from_file(m_read_bl, m_object_offset, m_object_len);
+  if(ret < 0) {
+    m_on_finish->complete(-1);
+    return;
+  }
+     
+  m_on_finish->complete(0); 
+}
+
+WriteSyncFileRequest::WriteSyncFileRequest(CephContext* cct, 
+                                           const std::string& file_name, 
+                                           ceph::bufferlist& write_bl, 
+                                           uint64_t object_off, 
+                                           uint64_t object_len,
+                                           Context* on_finish)
+  : m_sync_file(cct, file_name),
+    m_write_bl(write_bl),
+    m_object_offset(object_off),
+    m_object_len(object_len),
+    m_on_finish(on_finish)
+{}
+
+
+ void WriteSyncFileRequest::finish(int r) {
+  if(r < 0) {
+    m_on_finish->complete(-1);
+  }
+
+  int ret;
+
+  std::string temp_name = m_sync_file.get_ceph_context()->_conf.get_val<std::string>("rbd_shared_cache_path") + "/rbd_cache." 
+                                + m_sync_file.get_file_name() + "write_temp_file";
+
+  int flag = O_WRONLY | O_CREAT | O_DIRECT | O_SYNC | O_NOATIME;
+  ret = m_sync_file.open(flag, temp_name); 
+  if(ret < 0) {
+    m_on_finish->complete(-1); 
+    return;
+  }
+
+  ret = m_sync_file.write_object_to_file(m_write_bl, m_object_len);
+  if(ret < 0) {
+    m_on_finish->complete(-1);
+    return;
+  }
+
+  
+  ret = m_sync_file.rename(temp_name, m_sync_file.get_file_name());
+  if(ret < 0) {
+    m_on_finish->complete(-1);
+    return;
+  }
+  
+  m_on_finish->complete(0);
+    
+}
+
+
+DeleteSyncFileRequest::DeleteSyncFileRequest(CephContext* cct, 
+                                             ContextWQ* op_work_queue,
+                                             const std::string& file_name,
+                                             Context* on_finish) 
+  : m_sync_file(cct, file_name),
+    m_on_finish(on_finish),
+    m_op_work_queue(op_work_queue)
+{}
+
+void DeleteSyncFileRequest::finish(int r) {
+  if(r < 0) {
+    m_on_finish->complete(-1);
+    return;
+  }
+
+  int ret;
+  std::string temp_name = m_sync_file.get_file_name() + "delte_temp_file";
+  ret = m_sync_file.rename(m_sync_file.get_file_name(), temp_name); 
+  if(ret < 0) {
+    m_on_finish->complete(-1);
+    return;
+  }
+  m_sync_file.remove(temp_name);
+  m_on_finish->complete(0);
+
+}
+
+
 
 } // namespace cache
 } // namespace librbd

--- a/src/librbd/cache/SharedPersistentObjectCacherFile.h
+++ b/src/librbd/cache/SharedPersistentObjectCacherFile.h
@@ -5,6 +5,8 @@
 #define CEPH_LIBRBD_CACHE_STORE_SYNC_FILE
 
 #include "include/buffer_fwd.h"
+#include "include/Context.h"
+#include "common/WorkQueue.h"
 #include <sys/mman.h>
 #include <string>
 
@@ -20,6 +22,8 @@ class SyncFile {
 public:
   SyncFile(CephContext *cct, const std::string &name);
   ~SyncFile();
+
+//  virtual int send() = 0;
 
   // TODO use IO queue instead of individual commands so operations can be
   // submitted in batch
@@ -52,9 +56,24 @@ public:
 
   int remove();
 
-  // ##
+  // ============== new interface =================
+
+  int open(int flag, std::string temp_name);
+
+  int rename(std::string old_name, std::string new_name);
+ 
+  int remove(std::string delete_file_name);  
+
   int write_object_to_file(ceph::bufferlist read_buf, uint64_t object_len);
   int read_object_from_file(ceph::bufferlist* read_buf, uint64_t object_off, uint64_t object_len);
+
+  CephContext* get_ceph_context() {
+    return cct;
+  }
+
+  std::string get_file_name() {
+    return m_name;
+  }
 
 private:
   CephContext *cct;
@@ -67,6 +86,76 @@ private:
   int truncate(uint64_t length, bool fdatasync);
   int fdatasync();
 };
+
+
+class ReadSyncFileRequest : public Context {
+public:
+  ReadSyncFileRequest(CephContext* cct, ContextWQ* op_work_queue, 
+                      const std::string& file_name, ceph::bufferlist* read_bl,
+                      const uint64_t object_off, const uint64_t object_len,
+                      Context* on_finish);
+  ~ReadSyncFileRequest(){}
+
+  void finish(int r);
+
+  int send(){
+    m_op_work_queue->queue(this, 0);
+    return 0;
+  }
+
+private:
+  Context* m_on_finish;
+  SyncFile m_sync_file;
+  ceph::bufferlist* m_read_bl;
+  const uint64_t m_object_offset;
+  const uint64_t m_object_len;
+  ContextWQ* m_op_work_queue;
+};
+
+// =========
+
+class WriteSyncFileRequest : public Context {
+public:
+  WriteSyncFileRequest(CephContext* cct, const std::string& file_name, 
+                       ceph::bufferlist& write_bl,
+                       uint64_t object_off, 
+                       uint64_t object_len,
+                       Context* on_finish);
+  ~WriteSyncFileRequest(){}
+  int send(){
+    m_op_work_queue->queue(this, 0);
+    return 0;
+  }
+
+  void finish(int r);
+private:
+  ContextWQ* m_op_work_queue;
+  Context* m_on_finish;
+  SyncFile m_sync_file;
+  ceph::bufferlist& m_write_bl;
+  const uint64_t m_object_offset;
+  const uint64_t m_object_len;
+};
+
+
+class DeleteSyncFileRequest : public Context {
+public:
+  DeleteSyncFileRequest(CephContext* cct, ContextWQ* op_work_queue, 
+                        const std::string& file_name, 
+                        Context* on_finish);
+
+  ~DeleteSyncFileRequest(){}
+
+  void finish(int r);
+
+  int send(){return 0;}
+private:
+  SyncFile m_sync_file;
+  ContextWQ* m_op_work_queue;
+  Context* m_on_finish;
+};
+
+
 
 } // namespace cache
 } // namespace librbd


### PR DESCRIPTION
hi, yuan 
according to our discussion, implement some new features as following 
1: implement some new interface, including rename, open, remove, get_file_name, get_ceph_context  at syncfile. 

2: add three new class, including WriteSyncFIleRequest, ReadSyncFileRequest, DeleteSyncFileRequest.
the main aim of these class is to wrap file operation and implement async implement.

3: all in async implement is based on ceph ContextWQ. 

Now, read-only-cache still is using old sync interface, later i will modify all file calling using these new class.

for upper caller, usage method is simple as following 
for example:

step1 : Context* write_request = new WriteSyncFileRequest(...., callback);
step2 : write_request->send() 

when operation have been done, callback will be called.

 


