### PR TITLE
at librbd side, current all error can be catched, then do corresponding action to verify program stability. 

### DIFF
--- a/src/librbd/cache/SharedPersistentObjectCacherObjectDispatch.h
+++ b/src/librbd/cache/SharedPersistentObjectCacherObjectDispatch.h
@@ -118,12 +118,11 @@ private:
       uint64_t object_len, ceph::bufferlist* read_data,
       io::DispatchResult* dispatch_result,
       Context* on_dispatched);
+  void client_handle_request(std::string msg);
 
   ImageCtxT* m_image_ctx;
 
-  void client_handle_request(std::string msg);
   rbd::cache::CacheClient *m_cache_client = nullptr;
-  boost::asio::io_service io_service;
 };
 
 } // namespace cache

--- a/src/tools/rbd_cache/CacheController.cc
+++ b/src/tools/rbd_cache/CacheController.cc
@@ -68,9 +68,9 @@ void CacheController::run() {
     std::string controller_path = "/tmp/rbd_shared_readonly_cache_demo";
     std::remove(controller_path.c_str()); 
     
-    m_cache_server = new CacheServer(io_service, controller_path,
+    m_cache_server = new CacheServer(controller_path,
       ([&](uint64_t p, std::string s){handle_request(p, s);}));
-    io_service.run();
+    m_cache_server->run();
   } catch (std::exception& e) {
     std::cerr << "Exception: " << e.what() << "\n";
   }
@@ -105,7 +105,8 @@ void CacheController::handle_request(uint64_t session_id, std::string msg){
 
       break;
     }
-    
+    std::cout<<"can't recongize request"<<std::endl;
+    assert(0); // TODO replace it.
   }
 }
 

--- a/src/tools/rbd_cache/CacheController.h
+++ b/src/tools/rbd_cache/CacheController.h
@@ -41,7 +41,6 @@ class CacheController {
   void handle_request(uint64_t sesstion_id, std::string msg);
 
  private:
-  boost::asio::io_service io_service;
   CacheServer *m_cache_server;
   std::vector<const char*> m_args;
   CephContext *m_cct;

--- a/src/tools/rbd_cache/CacheControllerSocket.hpp
+++ b/src/tools/rbd_cache/CacheControllerSocket.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <boost/bind.hpp>
 #include <boost/asio.hpp>
+#include <boost/asio/error.hpp> 
 #include <boost/algorithm/string.hpp>
 #include "CacheControllerSocketCommon.h"
 
@@ -23,15 +24,80 @@ namespace cache {
 class session : public std::enable_shared_from_this<session> {
 public:
   session(uint64_t session_id, boost::asio::io_service& io_service, ProcessMsg processmsg)
-    : session_id(session_id), socket_(io_service), process_msg(processmsg) {}
+    : m_session_id(session_id), m_dm_socket(io_service), process_msg(processmsg) {}
 
   stream_protocol::socket& socket() {
-    return socket_;
+    return m_dm_socket;
   }
 
   void start() {
+    if(true) {
+      serial_handing_request();
+    } else { 
+      parallel_handing_request();
+    }
+  }
+  // flow: 
+  // 
+  // recv request --> process request --> reply ack
+  //   |                                      |
+  //   --------------<-------------------------
+  void serial_handing_request() {
+    boost::asio::async_read(m_dm_socket, boost::asio::buffer(m_buffer, 544),
+                            boost::asio::transfer_exactly(544),
+                            boost::bind(&session::handle_read,
+                                        shared_from_this(),
+                                        boost::asio::placeholders::error,
+                                        boost::asio::placeholders::bytes_transferred));
+  }
 
-    boost::asio::async_read(socket_, boost::asio::buffer(data_),
+  // flow : 
+  //
+  //              --> thread 1: process request  
+  // recv request --> thread 2: process request --> reply ack
+  //              --> thread n: process request  
+  //
+  void parallel_handing_request() {
+    // TODO
+  }
+
+private: 
+
+  void handle_read(const boost::system::error_code& error, size_t bytes_transferred) {
+    // when recv eof, the most proble is that client side close socket.
+    // so, server side need to end handing_request
+    if(error == boost::asio::error::eof) {
+      std::cout<<"session: async_read : " << error.message() << std::endl;
+      return;
+    }
+
+    if(error) {
+      std::cout<<"session: async_read fails: " << error.message() << std::endl;
+      assert(0);
+    }
+
+    if(bytes_transferred != 544) {
+      std::cout<<"session : request in-complete. "<<std::endl;
+      assert(0);
+    }
+
+    // TODO async_process can increse coding readable.
+    // process_msg_callback call handle async_send
+    process_msg(m_session_id, std::string(m_buffer, bytes_transferred));
+  }
+
+  void handle_write(const boost::system::error_code& error, size_t bytes_transferred) {
+    if (error) {
+      std::cout<<"session: async_write fails: " << error.message() << std::endl;
+      assert(0);
+    }
+
+    if(bytes_transferred != 544) {
+      std::cout<<"session : reply in-complete. "<<std::endl;
+      assert(0);
+    }
+
+    boost::asio::async_read(m_dm_socket, boost::asio::buffer(m_buffer),
                             boost::asio::transfer_exactly(544),
                             boost::bind(&session::handle_read,
                             shared_from_this(),
@@ -40,93 +106,119 @@ public:
 
   }
 
-  void handle_read(const boost::system::error_code& error, size_t bytes_transferred) {
-
-    if (!error) {
-      if(bytes_transferred != 544){
-	assert(0);
-      }
-      process_msg(session_id, std::string(data_, bytes_transferred));
-
-    }
-  }
-
-  void handle_write(const boost::system::error_code& error) {
-    if (!error) {
-    boost::asio::async_read(socket_, boost::asio::buffer(data_),
-                            boost::asio::transfer_exactly(544),
-          boost::bind(&session::handle_read,
-            shared_from_this(),
-            boost::asio::placeholders::error,
-            boost::asio::placeholders::bytes_transferred));
-    }
-  }
-
+public:
   void send(std::string msg) {
-
-      boost::asio::async_write(socket_,
+      boost::asio::async_write(m_dm_socket,
           boost::asio::buffer(msg.c_str(), msg.size()),
           boost::asio::transfer_exactly(544),
           boost::bind(&session::handle_write,
-            shared_from_this(),
-            boost::asio::placeholders::error));
+                      shared_from_this(),
+                      boost::asio::placeholders::error,
+                      boost::asio::placeholders::bytes_transferred));
 
   }
 
 private:
-  uint64_t session_id;
-  stream_protocol::socket socket_;
+  uint64_t m_session_id;
+  stream_protocol::socket m_dm_socket;
   ProcessMsg process_msg;
 
   // Buffer used to store data received from the client.
   //std::array<char, 1024> data_;
-  char data_[1024];
+  char m_buffer[1024];
 };
 
 typedef std::shared_ptr<session> session_ptr;
 
 class CacheServer {
 public:
-  CacheServer(boost::asio::io_service& io_service,
-         const std::string& file, ProcessMsg processmsg)
-    : io_service_(io_service),
-      server_process_msg(processmsg),
-      acceptor_(io_service, stream_protocol::endpoint(file))
-  {
-    session_ptr new_session(new session(session_id, io_service_, server_process_msg));
-    acceptor_.async_accept(new_session->socket(),
-        boost::bind(&CacheServer::handle_accept, this, new_session,
-          boost::asio::placeholders::error));
-  }
+  CacheServer(const std::string& file, ProcessMsg processmsg)
+    : m_server_process_msg(processmsg),
+      m_local_path(file),
+      m_acceptor(m_io_service)
+  {}
 
-  void handle_accept(session_ptr new_session,
-      const boost::system::error_code& error)
-  {
-    //TODO(): open librbd snap
-    if (!error) {
-      new_session->start();
-      session_map.emplace(session_id, new_session);
-      session_id++;
-      new_session.reset(new session(session_id, io_service_, server_process_msg));
-      acceptor_.async_accept(new_session->socket(),
-          boost::bind(&CacheServer::handle_accept, this, new_session,
-            boost::asio::placeholders::error));
+  void run() { 
+    bool ret;
+    ret = start_accept();
+    if(!ret) { 
+      return;
     }
+    m_io_service.run();
   }
 
+  // TODO : use callback to replace this function. 
   void send(uint64_t session_id, std::string msg) {
-    auto it = session_map.find(session_id);
-    if (it != session_map.end()) {
+    auto it = m_session_map.find(session_id);
+    if (it != m_session_map.end()) {
       it->second->send(msg);
+    } else {
+      // TODO : why don't find existing session id ?
+      std::cout<<"don't find session id..."<<std::endl;
+      assert(0);
     }
   }
 
 private:
-  boost::asio::io_service& io_service_;
-  ProcessMsg server_process_msg;
-  stream_protocol::acceptor acceptor_;
-  uint64_t session_id = 1;
-  std::map<uint64_t, session_ptr> session_map;
+  // when creating one acceptor, can control every step in this way.
+  bool start_accept() {
+    boost::system::error_code ec;
+    m_acceptor.open(m_local_path.protocol(), ec);
+    if(ec) {
+      std::cout << "m_acceptor open fails: " << ec.message() << std::endl;
+      return false;
+    }
+
+    // TODO control acceptor attribute.
+
+    m_acceptor.bind(m_local_path, ec);
+    if(ec) { 
+      std::cout << "m_acceptor bind fails: " << ec.message() << std::endl;
+      return false;
+    }
+
+    m_acceptor.listen(boost::asio::socket_base::max_connections, ec);
+    if(ec) {
+      std::cout << "m_acceptor listen fails: " << ec.message() << std::endl;
+      return false;
+    }
+
+    accept();
+    return true;
+  }
+
+  void accept() {
+    session_ptr new_session(new session(m_session_id, m_io_service, m_server_process_msg));
+    m_acceptor.async_accept(new_session->socket(),
+        boost::bind(&CacheServer::handle_accept, this, new_session,
+          boost::asio::placeholders::error));
+  }
+
+ void handle_accept(session_ptr new_session, const boost::system::error_code& error) {
+    //TODO(): open librbd snap ... yuan
+
+    if(error) { 
+      std::cout << "async accept fails : " << error.message() << std::endl;
+      assert(0); // TODO
+    }
+
+      // must put session into m_session_map at the front of session.start()
+    m_session_map.emplace(m_session_id, new_session);
+    // TODO : session setting 
+    new_session->start();
+    m_session_id++;
+
+    // lanuch next accept 
+    accept();
+  }
+
+private:
+  boost::asio::io_service m_io_service; // TODO wrapper it.
+  stream_protocol::endpoint m_local_path; 
+  ProcessMsg m_server_process_msg;
+  stream_protocol::acceptor m_acceptor;
+  uint64_t m_session_id = 1;
+  std::map<uint64_t, session_ptr> m_session_map;
 };
 
 } // namespace cache

--- a/src/tools/rbd_cache/CacheControllerSocketClient.hpp
+++ b/src/tools/rbd_cache/CacheControllerSocketClient.hpp
@@ -6,7 +6,9 @@
 
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
+#include <boost/asio/error.hpp>
 #include <boost/algorithm/string.hpp>
+#include "librbd/ImageCtx.h"
 #include "include/assert.h"
 #include "include/Context.h"
 #include "CacheControllerSocketCommon.h"
@@ -19,31 +21,42 @@ namespace cache {
 
 class CacheClient {
 public:
-  CacheClient(boost::asio::io_service& io_service,
-              const std::string& file, ClientProcessMsg processmsg)
-    : io_service_(io_service),
-      io_service_work_(io_service),
-      socket_(io_service),
+  CacheClient(const std::string& file, ClientProcessMsg processmsg, CephContext* ceph_ctx)
+    : m_io_service_work(m_io_service),
+      m_dm_socket(m_io_service),
       m_client_process_msg(processmsg),
-      ep_(stream_protocol::endpoint(file))
+      m_ep(stream_protocol::endpoint(file)),
+      cct(ceph_ctx)
   {
-     io_thread.reset(new std::thread([this](){io_service_.run(); }));
-  }
-
-  ~CacheClient() {
-    io_service_.stop();
-    io_thread->join();
+     // TODO wrapper io_service
+     std::thread thd([this](){  
+                      m_io_service.run();});
+     thd.detach();
   }
 
   void run(){
   } 
 
   int connect() {
-    try {
-      socket_.connect(ep_);
-    } catch (std::exception& e) {
-      return -1;
+    boost::system::error_code ec;
+    m_dm_socket.connect(m_ep, ec);
+    if(ec) {
+      //ldout(cct, 20) << "connect: " << ec.message() << dendl;
+      if(m_dm_socket.is_open()) {
+        // Set to indicate what error occurred, if any. 
+        // Note that, even if the function indicates an error, 
+        // the underlying descriptor is closed.
+        boost::system::error_code close_ec;
+        m_dm_socket.close(close_ec);
+        if(close_ec) {
+          //ldout(cct, 20) << "close: " << close_ec.message() << dendl;
+        }
+      }
+      return -1; 
     }
+    
+    std::cout<<"connect success"<<std::endl;
+
     connected = true;
     return 0;
   }
@@ -57,27 +70,49 @@ public:
     message->vol_size = vol_size;
     message->offset = 0;
     message->length = 0;
-    boost::asio::async_write(socket_,  boost::asio::buffer((char*)message, message->size()),
-        [this, message](const boost::system::error_code& err, size_t cb) {
-        delete message;
-        if (!err) {
-          boost::asio::async_read(socket_, boost::asio::buffer(buffer_),
-              boost::asio::transfer_exactly(544),
-              [this](const boost::system::error_code& err, size_t cb) {
-              if (!err) {
-                m_client_process_msg(std::string(buffer_, cb));
-              } else {
-                  return -1;
-              }
-          });
-        } else {
-          return -1;
-        }
-    });
+
+    uint64_t ret;
+    boost::system::error_code ec;
+
+    ret = boost::asio::write(m_dm_socket, boost::asio::buffer((char*)message, message->size()), ec);
+    if(ec) {
+      //ldcout << "write fails : " << ec.message() << dendl;
+      assert(0);
+    }
+
+    if(ret != message->size()) {
+      //ldcout << "write fails : ret != send_bytes "<< dendl;
+      assert(0);
+    }    
+
+    // hard code TODO
+    char* receive_buffer = new char[544 + 1];
+    ret = boost::asio::read(m_dm_socket, boost::asio::buffer(receive_buffer, 544), ec);
+    if(ec == boost::asio::error::eof) {
+      std::cout<< "recv eof"<<std::endl;
+      return -1;
+    }
+    if(ec) {
+      //ldcout << "write fails : " << ec.message() << dendl;
+      assert(0);
+    }
+
+    if(ret != 544) {
+      //ldcout << "write fails : ret != receive bytes " << dendl;
+      assert(0);
+    }
+
+    m_client_process_msg(std::string(receive_buffer, ret));
+    
+    delete[] receive_buffer;
+    // delete message;
+    
+    std::cout << "register volume success" << std::endl;
 
     return 0;
   }
 
+  // if occur any error, we just return false. Then read from rados.
   int lookup_object(std::string pool_name, std::string vol_name, std::string object_id, Context* on_finish) {
     rbdsc_req_type_t *message = new rbdsc_req_type_t();
     message->type = RBDSC_READ;
@@ -87,57 +122,84 @@ public:
     message->offset = 0;
     message->length = 0;
 
-    boost::asio::async_write(socket_,  boost::asio::buffer((char*)message, message->size()),
+    boost::asio::async_write(m_dm_socket,  
+                             boost::asio::buffer((char*)message, message->size()),
+                             boost::asio::transfer_exactly(544),
         [this, on_finish, message](const boost::system::error_code& err, size_t cb) {
-        delete message;
-        if (!err) {
+          delete message;
+          if(err) {
+            std::cout<< "lookup_object: async_write fails." << err.message() << std::endl;
+            on_finish->complete(false);
+            return;
+          }
+          if(cb != 544) {
+            std::cout<< "lookup_object: async_write fails. in-complete request" <<std::endl;
+            on_finish->complete(false);
+            return;
+          }
           get_result(on_finish);
-        } else {
-          return -1;
-        }
     });
 
     return 0;
   }
 
   void get_result(Context* on_finish) {
-    boost::asio::async_read(socket_, boost::asio::buffer(buffer_),
-        boost::asio::transfer_exactly(544),
+    boost::asio::async_read(m_dm_socket, boost::asio::buffer(m_recv_buffer, 544),
+                            boost::asio::transfer_exactly(544),
         [this, on_finish](const boost::system::error_code& err, size_t cb) {
-        if (cb != 544) {
-	  assert(0);
-        }
-        if (!err) {
-	    rbdsc_req_type_t *io_ctx = (rbdsc_req_type_t*)(buffer_);
-            if (io_ctx->type == RBDSC_READ_REPLY) {
-	      on_finish->complete(true);
-              return;
-            } else {
-	      on_finish->complete(false);
-              return;
-            }
-        } else {
-	    assert(0);
-            return on_finish->complete(false);
-        }
+          if(err == boost::asio::error::eof) {
+            std::cout<<"get_result: ack is EOF." << std::endl;
+            on_finish->complete(false);
+            return;
+          }
+          if(err) {
+            std::cout<< "get_result: async_read fails:" << err.message() << std::endl;
+            on_finish->complete(false); // TODO replace this assert with some metohds.
+            return;
+          }
+          if (cb != 544) {
+            std::cout << "get_result: in-complete ack." << std::endl;
+	    on_finish->complete(false); // TODO: replace this assert with some methods.
+          }
+
+	  rbdsc_req_type_t *io_ctx = (rbdsc_req_type_t*)(m_recv_buffer);
+          
+          // TODO: re-occur yuan's bug
+          if(io_ctx->type == RBDSC_READ) {
+            std::cout << "get rbdsc_read... " << std::endl;
+            assert(0);
+          }
+
+          if (io_ctx->type == RBDSC_READ_REPLY) {
+	    on_finish->complete(true);
+            return;
+          } else {
+	    on_finish->complete(false);
+            return;
+          }
     });
   }
 
+  void handle_connect(const boost::system::error_code& error) {
+    //TODO(): open librbd snap
+  }
+
+  void handle_write(const boost::system::error_code& error) {
+  }
 
 private:
-  boost::asio::io_service& io_service_;
-  boost::asio::io_service::work io_service_work_;
-  stream_protocol::socket socket_;
-
-  std::shared_ptr<std::thread> io_thread;
+  boost::asio::io_service m_io_service;
+  boost::asio::io_service::work m_io_service_work;
+  stream_protocol::socket m_dm_socket;
   ClientProcessMsg m_client_process_msg;
-  stream_protocol::endpoint ep_;
-  char buffer_[1024];
+  stream_protocol::endpoint m_ep;
+  char m_recv_buffer[1024];
   int block_size_ = 1024;
 
   std::condition_variable cv;
   std::mutex m;
-
+  
+  CephContext* cct;
 public:
   bool connected = false;
 };


### PR DESCRIPTION
this PR is based on last PR, so just cherrypick 1a5516f commit. 

the error of librbd side will be catched, then do corresponding handing as following: 
if one error occur at session, i think this session can't work normally. So, current request will be re-directly to Rados, then later all request will be re-directed to Rados layer. 

if connection and register don't finish, SRO will be ignored. 

if controller crash, librbd side can detect it, and re-direct all read request. 

i have tested it at these cases, and run for several hours.  
